### PR TITLE
feat: allow batch claim up to 15 requests per batch

### DIFF
--- a/contracts/observer/EpochMerkleDistributor.sol
+++ b/contracts/observer/EpochMerkleDistributor.sol
@@ -51,8 +51,15 @@ contract EpochMerkleDistributor is IEpochMerkleDistributor {
         emit Claim(epoch, index, account, amount);
     }
 
-    function claim(ClaimRequest calldata claimRequests) external override {
-        return _claim(epoch, index, account, amount, merkleProof);
+    function claim(ClaimRequest calldata claimRequest) external override {
+        return
+            _claim(
+                claimRequest.epoch,
+                claimRequest.index,
+                claimRequest.account,
+                claimRequest.amount,
+                claimRequest.merkleProof
+            );
     }
 
     function batchClaim(ClaimRequest[] calldata claimRequests) external override {

--- a/contracts/observer/interfaces/IEpochMerkleDistributor.sol
+++ b/contracts/observer/interfaces/IEpochMerkleDistributor.sol
@@ -22,7 +22,7 @@ interface IEpochMerkleDistributor {
     function isClaimed(uint256 epoch, uint256 index) external view returns (bool);
 
     /// Claim from the epoch, tokens to the provided address.
-    function claim(ClaimRequest claimRequest) external;
+    function claim(ClaimRequest calldata claimRequest) external;
 
     /// Batch claim from a number of epics, tokens to the provided address.
     function batchClaim(ClaimRequest[] calldata claimRequests) external;


### PR DESCRIPTION
- Allow batch claim of token reward

The current batch claim allows up to 15 requests per batch to keep the gas usage between 151460  -  584403
Also, to optimize gas, any invalid requests in the batch is skipped and the valid request is processed 

See gas usage for both single claim and batch claim requests
![image](https://user-images.githubusercontent.com/22542946/138287520-2180a526-6730-46b4-94ad-b61abdb54c49.png)

Single claim up to 15 requests will cost over 1,173,060 gas